### PR TITLE
Detect dirty git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ The plugin offers some options for customizing the appearance of the generated i
 
 ```groovy
 appiconoverlay {
-    textColor '#FFF'           /* #rrggbbaa format */
-    backgroundColor "#0008"    /* #rrggbbaa format */
-    format '$branch\n$commit'  /* GString */
-    imageMagick 'convert'      /* command to run ImageMagick */
-    dirtyCheck false           /* flag to enabled/disabled dirty check */
-    dirtyColor '#F00'          /* #rrggbbaa format */
+    textColor '#FFF'                        /* #rrggbbaa format */
+    backgroundColor "#0008"                 /* #rrggbbaa format */
+    format '$branch\n$commit'               /* GString */
+    imageMagick 'convert'                   /* command to run ImageMagick */
+    dirtyCheck false                        /* flag to enabled/disabled dirty check */
+    dirtyColor '#F00'                       /* #rrggbbaa format */
+    dirtyFormat '$branch\n$commit (dirty)'  /* GString */
 }
 ```
 
@@ -70,6 +71,7 @@ Option                 | Description
 `imageMagick`          | Command to run ImageMagick's "convert".
 `dirtyCheck`           | Flag to enable/disable check if repo has unstaged or uncommitted files (is dirty)
 `dirtyColor`           | Text color in #rrggbbaa format used if repo is dirty (see dirtyCheck)
+`dirtyFormat`          | Format string to be used to create the text in the overlay in case repo is dirty.<br>See format<br/>See dirtyCheck
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ appiconoverlay {
     backgroundColor "#0008"    /* #rrggbbaa format */
     format '$branch\n$commit'  /* GString */
     imageMagick 'convert'      /* command to run ImageMagick */
+    dirtyCheck false           /* flag to enabled/disabled dirty check */
+    dirtyColor '#F00'          /* #rrggbbaa format */
 }
 ```
 
@@ -66,6 +68,8 @@ Option                 | Description
 `backgroundColor`      | Background color for overlay in #rrggbbaa format.
 `format`               | Format string to be used to create the text in the overlay.<br />*Note*: Use single quotes, it's a GString.<br />The following variables are available: <ul><li>`$branch` name of git branch</li> <li>`$commit` short SHA1 of latest commit in current branch</li></ul>
 `imageMagick`          | Command to run ImageMagick's "convert".
+`dirtyCheck`           | Flag to enable/disable check if repo has unstaged or uncommitted files (is dirty)
+`dirtyColor`           | Text color in #rrggbbaa format used if repo is dirty (see dirtyCheck)
 
 
 ## Credits

--- a/src/main/groovy/com/github/splatte/android/AppIconOverlayPlugin.groovy
+++ b/src/main/groovy/com/github/splatte/android/AppIconOverlayPlugin.groovy
@@ -59,4 +59,15 @@ class AppIconOverlayExtension {
      * Command to invoke to run ImageMagick's "convert".
      */
     String imageMagick = "convert"
+
+    /**
+     * Flag to indicate if git repo is dirty (unstaged or uncommitted changes,
+     * untracked files) to use dirtyColor as textColor.
+     */
+    boolean dirtyCheck = false
+
+    /**
+     * Text color in #rrggbbaa format used when git repo is dirty. See dirtyCheck.
+     */
+    String dirtyColor = "#F00"
 }

--- a/src/main/groovy/com/github/splatte/android/AppIconOverlayPlugin.groovy
+++ b/src/main/groovy/com/github/splatte/android/AppIconOverlayPlugin.groovy
@@ -70,4 +70,11 @@ class AppIconOverlayExtension {
      * Text color in #rrggbbaa format used when git repo is dirty. See dirtyCheck.
      */
     String dirtyColor = "#F00"
+
+    /**
+     * Format string to be used to create the text in the overlay in case repo is dirty.
+     * See format.
+     * See dirtyCheck.
+     */
+    String dirtyFormat = '$branch\n$commit (dirty)'
 }

--- a/src/main/groovy/com/github/splatte/android/OverlayTask.groovy
+++ b/src/main/groovy/com/github/splatte/android/OverlayTask.groovy
@@ -39,11 +39,13 @@ class OverlayTask extends DefaultTask {
                     caption = "<no git>"
                 }
 
+                boolean isGitDirty = project.appiconoverlay.dirtyCheck && isGitDirty();
+
                 /* invoke ImageMagick */
                 try {
                     def imagemagick = ["${project.appiconoverlay.imageMagick}",
                         "-background", "${project.appiconoverlay.backgroundColor}",
-                        "-fill", "${project.appiconoverlay.textColor}",
+                        "-fill", isGitDirty ? "${project.appiconoverlay.dirtyColor}" : "${project.appiconoverlay.textColor}",
                         "-gravity", "center",
                         "-size", "${img.width}x${img.height / 2}",
                         "caption:${caption}",
@@ -64,6 +66,14 @@ class OverlayTask extends DefaultTask {
                 }
             }
         }
+    }
+
+    boolean isGitDirty() {
+        // check if repo has unstaged or uncommitted changes
+        def args = ["git", "diff-index", "--quiet", "HEAD", "--"]
+        def git = args.execute(null, project.projectDir)
+        int exitValue = git.waitFor()
+        exitValue == 1
     }
 
     def queryGit(def command) {

--- a/src/main/groovy/com/github/splatte/android/OverlayTask.groovy
+++ b/src/main/groovy/com/github/splatte/android/OverlayTask.groovy
@@ -28,8 +28,11 @@ class OverlayTask extends DefaultTask {
                 logger.debug("found file: ${file}")
 
                 def img = ImageIO.read(file);
+                boolean isGitDirty = project.appiconoverlay.dirtyCheck && isGitDirty();
                 def formatBinding = ['branch': queryGit("abbrev-ref"), 'commit': queryGit("short")]
-                def caption = new SimpleTemplateEngine().createTemplate(project.appiconoverlay.format).make(formatBinding)
+                def caption = new SimpleTemplateEngine().createTemplate(
+                        isGitDirty ? project.appiconoverlay.dirtyFormat : project.appiconoverlay.format)
+                        .make(formatBinding)
 
                 /*
                  * caption might end up being only \n, in which case imagemagick will hang and the call never completes
@@ -39,7 +42,6 @@ class OverlayTask extends DefaultTask {
                     caption = "<no git>"
                 }
 
-                boolean isGitDirty = project.appiconoverlay.dirtyCheck && isGitDirty();
 
                 /* invoke ImageMagick */
                 try {

--- a/src/main/groovy/com/github/splatte/android/OverlayTask.groovy
+++ b/src/main/groovy/com/github/splatte/android/OverlayTask.groovy
@@ -70,23 +70,19 @@ class OverlayTask extends DefaultTask {
 
     boolean isGitDirty() {
         // check if repo has unstaged or uncommitted changes
-        def args = ["git", "diff-index", "--quiet", "HEAD", "--"]
-        def git = args.execute(null, project.projectDir)
-        int exitValue = git.waitFor()
-        exitValue == 1
+        def process = executeShell(["git", "diff-index", "--quiet", "HEAD", "--"])
+        process.exitValue() != 0
     }
 
     def queryGit(def command) {
-        def args = ["git", "rev-parse", "--${command}", "HEAD"]
-        logger.debug("executing git: ${args.join(' ')}")
+        def process = executeShell(["git", "rev-parse", "--${command}", "HEAD"])
+        process.in.text.replaceAll(/\s/, "")
+    }
 
-        def git = args.execute(null, project.projectDir)
-        git.waitFor()
-
-        if(git.exitValue() != 0) {
-            logger.error("git exited with a non-zero error code. Is there a .git directory?")
-        }
-
-        git.in.text.replaceAll(/\s/, "")
+    def executeShell(def args) {
+        logger.debug("executing shell: ${args.join(' ')}")
+        def process = args.execute(null, project.projectDir)
+        process.waitFor()
+        process
     }
 }


### PR DESCRIPTION
This cool little gradle plugin has one issue in case the git repo is dirty, meaning has unstaged or uncommitted changes.
The branch name and short commit hash on the app icon is not indicating if the the repo was dirty when compiling so you can't really rely on the information when giving the debug build to someone. It might have some unknown changes compiled in this build or not.

I suggest to detect if git repo is dirty and show it with different text colour, e.g. red. Of course other visualizations would be possible e.g. $branch\n$commit\n(dirty), but i leave this for discussion.

The implementation provides a flag to enable/disable the dirty check (disabled by default, could be enabled by default?).
