### PR TITLE
Added support for build variant text

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ The plugin offers some options for customizing the appearance of the generated i
 
 ```groovy
 appiconoverlay {
-    textColor '#FFF'           	/* #rrggbbaa format */
-    backgroundColor "#0008"    	/* #rrggbbaa format */
+    textColor '#FFF'                  /* #rrggbbaa format */
+    backgroundColor "#0008"           /* #rrggbbaa format */
     format '$build->$branch\n$commit' /* GString */
-    imageMagick 'convert'     		/* command to run ImageMagick */
+    imageMagick 'convert'             /* command to run ImageMagick */
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ The plugin offers some options for customizing the appearance of the generated i
 
 ```groovy
 appiconoverlay {
-    textColor '#FFF'           /* #rrggbbaa format */
-    backgroundColor "#0008"    /* #rrggbbaa format */
-    format '$branch\n$commit'  /* GString */
-    imageMagick 'convert'      /* command to run ImageMagick */
+    textColor '#FFF'           	/* #rrggbbaa format */
+    backgroundColor "#0008"    	/* #rrggbbaa format */
+    format '$build->$branch\n$commit' /* GString */
+    imageMagick 'convert'     		/* command to run ImageMagick */
 }
 ```
 
@@ -64,7 +64,7 @@ Option                 | Description
 ---------------------- | ------------------
 `textColor`            | Text color in #rrggbbaa format.
 `backgroundColor`      | Background color for overlay in #rrggbbaa format.
-`format`               | Format string to be used to create the text in the overlay.<br />*Note*: Use single quotes, it's a GString.<br />The following variables are available: <ul><li>`$branch` name of git branch</li> <li>`$commit` short SHA1 of latest commit in current branch</li></ul>
+`format`               | Format string to be used to create the text in the overlay.<br />*Note*: Use single quotes, it's a GString.<br />The following variables are available: <ul><li>`$branch` name of git branch</li> <li>`$commit` short SHA1 of latest commit in current branch</li> <li>`$build` the name of the build variant ex. Debug</li></ul>
 `imageMagick`          | Command to run ImageMagick's "convert".
 
 

--- a/src/main/groovy/com/github/splatte/android/AppIconOverlayPlugin.groovy
+++ b/src/main/groovy/com/github/splatte/android/AppIconOverlayPlugin.groovy
@@ -25,6 +25,7 @@ class AppIconOverlayPlugin implements Plugin<Project> {
                 def overlayTask = project.task(type:OverlayTask, "${TASK_NAME}${variant.name.capitalize()}") {
                     manifestFile = output.processManifest.manifestOutputFile
                     resourcesPath = variant.mergeResources.outputDir
+                    buildVariant = "${variant.name.capitalize()}"
                 }
 
                 /* hook overlay task into android build chain */
@@ -52,8 +53,9 @@ class AppIconOverlayExtension {
      * The following variables are available:
      *     - $branch: name of git branch
      *     - $commit: short SHA1 of latest commit in current branch
+     *     - $build: the name of the build variant ex. Debug
      */
-    String format = '$branch\n$commit'
+    String format = '$build->$branch\n$commit'
 
     /**
      * Command to invoke to run ImageMagick's "convert".

--- a/src/main/groovy/com/github/splatte/android/OverlayTask.groovy
+++ b/src/main/groovy/com/github/splatte/android/OverlayTask.groovy
@@ -11,6 +11,7 @@ import org.gradle.api.tasks.TaskAction
 class OverlayTask extends DefaultTask {
     File manifestFile
     File resourcesPath
+    String buildVariant
 
     @TaskAction
     def overlay() {
@@ -28,7 +29,7 @@ class OverlayTask extends DefaultTask {
                 logger.debug("found file: ${file}")
 
                 def img = ImageIO.read(file);
-                def formatBinding = ['branch': queryGit("abbrev-ref"), 'commit': queryGit("short")]
+                def formatBinding = ['branch': queryGit("abbrev-ref"), 'commit': queryGit("short"), 'build': buildVariant]
                 def caption = new SimpleTemplateEngine().createTemplate(project.appiconoverlay.format).make(formatBinding)
 
                 /*


### PR DESCRIPTION
In our projects we have multiple build variants that can be side loaded next to each other.  So this new variable to the format allows for the build name to be part of the icon tagging.  The build variants can be 'Debug', 'Alpha', or 'Beta' which this can now handle.
