### PR TITLE
Updates for Gradle 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ Plugin for Android Gradle to automatically overlay the app icon with information
     }
     ```
 
-3. You will need ``convert`` from the [ImageMagick](http://imagemagick.org/) project to do the image processing. You can install it using a command along the lines of:
+3. For those using Gradle 3.+ disable aapt2 in your app module's ``gradle.properties`` file:
+
+    ```groovy
+    android.enableAapt2=false
+    ```
+
+4. You will need ``convert`` from the [ImageMagick](http://imagemagick.org/) project to do the image processing. You can install it using a command along the lines of:
 
     ```bash
     # debian/ubuntu

--- a/src/main/groovy/com/github/splatte/android/AppIconOverlayPlugin.groovy
+++ b/src/main/groovy/com/github/splatte/android/AppIconOverlayPlugin.groovy
@@ -23,7 +23,16 @@ class AppIconOverlayPlugin implements Plugin<Project> {
             variant.outputs.each { output ->
                 /* set up overlay task */
                 def overlayTask = project.task(type:OverlayTask, "${TASK_NAME}${variant.name.capitalize()}") {
-                    manifestFile = output.processManifest.manifestOutputFile
+                    try {
+                        // Android Gradle Plugin < 3.0.0
+                        manifestFile = output.processManifest.manifestOutputFile
+                    } catch (Exception ignored) {
+                        // Android Gradle Plugin >= 3.0.0
+                        manifestFile = new File(output.processManifest.manifestOutputDirectory, "AndroidManifest.xml")
+                        if (!manifestFile.isFile()) {
+                            manifestFile = new File(new File(output.processManifest.manifestOutputDirectory, output.dirName),"AndroidManifest.xml")
+                        }
+                    }
                     resourcesPath = variant.mergeResources.outputDir
                     buildVariant = "${variant.name.capitalize()}"
                 }


### PR DESCRIPTION
Fixed some issues that came up with Gradle 3.0

1. Added check for manifestOutputFile and if it doesn't exist move to the new manifestOutputDirectory.
2. In Gradle 3 AAPT2 (Android Asset Packaging Tool) is enabled by default which optimizes resources but changes all resources into .flat files which we cannot modify (As far as I can tell). Therefore in the readme I added the step to disable this so that we can get the resources we can modify. This will slow down build time a little bit since it is using the older AAPT but I couldn't find any other solutions.

Fixes #8